### PR TITLE
Update base.py

### DIFF
--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -148,11 +148,11 @@ class BaseModel(object):
             self.iterator = CropsFromTrialsIterator(
                 batch_size=batch_size, input_time_length=input_time_length,
                 n_preds_per_input=n_preds_per_input,
-                seed=self.seed_rng.randint(0, 4294967295))
+                seed=self.seed_rng.randint(0, np.iinfo(np.int32).max-1))
         else:
             self.iterator = BalancedBatchSizeIterator(
                 batch_size=batch_size,
-                seed=self.seed_rng.randint(0, 4294967295))
+                seed=self.seed_rng.randint(0, np.iinfo(np.int32).max-1))
         stop_criterion = MaxEpochs(epochs - 1)# -1 since we dont print 0 epoch, which matters for this stop criterion
         train_set = SignalAndTarget(train_X, train_y)
         optimizer = self.optimizer


### PR DESCRIPTION
Changed hard-coded randit upper bound value (4294967295) with np.iinfo(np.int32).max-1.
In windows 64bit with Conda , the randint fails with the  hard-coded value (4294967295).