### PR TITLE
Fix TypeError

### DIFF
--- a/braindecode/datasets/bbci.py
+++ b/braindecode/datasets/bbci.py
@@ -146,7 +146,7 @@ class BBCIDataset(object):
         with h5py.File(filename, "r") as h5file:
             clab_set = h5file["nfo"]["clab"][:].squeeze()
             all_sensor_names = [
-                "".join(chr(c) for c in h5file[obj_ref]) for obj_ref in clab_set
+                "".join(chr(c.item()) for c in h5file[obj_ref]) for obj_ref in clab_set
             ]
             if pattern is not None:
                 all_sensor_names = filter(
@@ -164,7 +164,7 @@ class BBCIDataset(object):
             # Check whether class names known and correct order
             class_name_set = h5file["nfo"]["className"][:].squeeze()
             all_class_names = [
-                "".join(chr(c) for c in h5file[obj_ref])
+                "".join(chr(c.item()) for c in h5file[obj_ref])
                 for obj_ref in class_name_set
             ]
 


### PR DESCRIPTION
For me on python 3.7 this threw TypeError: only integer scalar arrays can be converted to a scalar index, because the numpy array is a scalar and for some reason not accepted anymore by chr out of the box